### PR TITLE
Fixed CosmosSettings struct initialization

### DIFF
--- a/Cosmos/CosmosSettings.swift
+++ b/Cosmos/CosmosSettings.swift
@@ -6,8 +6,6 @@ Settings that define the appearance of the star rating views.
 
 */
 public struct CosmosSettings {
-  init() {}
-  
   // MARK: - Star settings
   // -----------------------------
     

--- a/Distrib/CosmosDistrib.swift
+++ b/Distrib/CosmosDistrib.swift
@@ -995,8 +995,6 @@ Settings that define the appearance of the star rating views.
 
 */
 public struct CosmosSettings {
-  init() {}
-  
   // MARK: - Star settings
   // -----------------------------
     


### PR DESCRIPTION
`init` method is internal by default, so it was impossible to create `CosmosSettings` object from outside to Cosmos project. 

It's possible now 🎉