### PR TITLE
CosmosSettings initialization improvement

### DIFF
--- a/Cosmos/CosmosSettings.swift
+++ b/Cosmos/CosmosSettings.swift
@@ -6,7 +6,13 @@ Settings that define the appearance of the star rating views.
 
 */
 public struct CosmosSettings {
-  init() {}
+
+  /// Returns default set of settings for CosmosView
+  public static var `default`: CosmosSettings {
+    return CosmosSettings()
+  }
+
+  public init() {}
   
   // MARK: - Star settings
   // -----------------------------

--- a/Cosmos/CosmosView.swift
+++ b/Cosmos/CosmosView.swift
@@ -58,8 +58,8 @@ Shows: ★★★★☆ (123)
   Initializes and returns a newly allocated cosmos view object.
   
   */
-  convenience public init(settings: CosmosSettings = .default) {
-    self.init(frame: CGRect())
+  public convenience init(settings: CosmosSettings = .default) {
+    self.init(frame: .zero, settings: settings)
   }
 
   /**
@@ -69,8 +69,13 @@ Shows: ★★★★☆ (123)
   - parameter frame: The frame rectangle for the view.
   
   */
-  override public init(frame: CGRect) {
+  override public convenience init(frame: CGRect) {
+    self.init(frame: frame, settings: .default)
+  }
+
+  public init(frame: CGRect, settings: CosmosSettings) {
     super.init(frame: frame)
+    self.settings = settings
     update()
     improvePerformance()
   }

--- a/Cosmos/CosmosView.swift
+++ b/Cosmos/CosmosView.swift
@@ -37,7 +37,7 @@ Shows: ★★★★☆ (123)
   }
   
   /// Star rating settings.
-  open var settings = CosmosSettings() {
+  open var settings: CosmosSettings = .default {
     didSet {
       update()
     }
@@ -52,17 +52,16 @@ Shows: ★★★★☆ (123)
     
     update()
   }
-  
-  
+
   /**
 
   Initializes and returns a newly allocated cosmos view object.
   
   */
-  convenience public init() {
+  convenience public init(settings: CosmosSettings = .default) {
     self.init(frame: CGRect())
   }
-  
+
   /**
 
   Initializes and returns a newly allocated cosmos view object with the specified frame rectangle.

--- a/Distrib/CosmosDistrib.swift
+++ b/Distrib/CosmosDistrib.swift
@@ -995,7 +995,13 @@ Settings that define the appearance of the star rating views.
 
 */
 public struct CosmosSettings {
-  init() {}
+
+  /// Returns default set of settings for CosmosView
+  public static var `default`: CosmosSettings {
+    return CosmosSettings()
+  }
+
+  public init() {}
   
   // MARK: - Star settings
   // -----------------------------
@@ -1184,7 +1190,7 @@ Shows: ★★★★☆ (123)
   }
   
   /// Star rating settings.
-  open var settings = CosmosSettings() {
+  open var settings: CosmosSettings = .default {
     didSet {
       update()
     }
@@ -1199,17 +1205,16 @@ Shows: ★★★★☆ (123)
     
     update()
   }
-  
-  
+
   /**
 
   Initializes and returns a newly allocated cosmos view object.
   
   */
-  convenience public init() {
+  convenience public init(settings: CosmosSettings = .default) {
     self.init(frame: CGRect())
   }
-  
+
   /**
 
   Initializes and returns a newly allocated cosmos view object with the specified frame rectangle.

--- a/Distrib/CosmosDistrib.swift
+++ b/Distrib/CosmosDistrib.swift
@@ -1211,8 +1211,8 @@ Shows: ★★★★☆ (123)
   Initializes and returns a newly allocated cosmos view object.
   
   */
-  convenience public init(settings: CosmosSettings = .default) {
-    self.init(frame: CGRect())
+  public convenience init(settings: CosmosSettings = .default) {
+    self.init(frame: .zero, settings: settings)
   }
 
   /**
@@ -1222,8 +1222,13 @@ Shows: ★★★★☆ (123)
   - parameter frame: The frame rectangle for the view.
   
   */
-  override public init(frame: CGRect) {
+  override public convenience init(frame: CGRect) {
+    self.init(frame: frame, settings: .default)
+  }
+
+  public init(frame: CGRect, settings: CosmosSettings) {
     super.init(frame: frame)
+    self.settings = settings
     update()
     improvePerformance()
   }


### PR DESCRIPTION
It's an improved version of my other PR #93

- You can create a `CosmosSettings` instance to have two or more `CosmosView`s  with the same settings set
- `init` method for `CosmosView` was improved with settings parameter