### PR TITLE
Allow CosmosView Customization From Interface Builder

### DIFF
--- a/Cosmos.xcodeproj/project.pbxproj
+++ b/Cosmos.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		7EE7F1E11E33254800995862 /* RightToLeft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE7F1E01E33254800995862 /* RightToLeft.swift */; };
 		7EE834C11B9D0270007BFDD2 /* CosmosAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE834C01B9D0270007BFDD2 /* CosmosAccessibility.swift */; };
 		7EF4F8251D91E97F00799197 /* CosmosSettingsObjCBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF4F8241D91E97F00799197 /* CosmosSettingsObjCBridge.swift */; };
+		89C3109920A625B1001FCA22 /* CosmosView.swift in Headers */ = {isa = PBXBuildFile; fileRef = 2B622ECA1B37BB700090D81B /* CosmosView.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -336,6 +337,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2B622EB31B37BAE50090D81B /* Cosmos.h in Headers */,
+				89C3109920A625B1001FCA22 /* CosmosView.swift in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Currently if Cosmos is setup using Carthage, it is not possible to customize the CosmosView within Interface Builder. More discussion surrounding this problem can be found [here](https://github.com/Carthage/Carthage/issues/335#issuecomment-100638372). The solution, discovered by @toshi0383 and discussed [here](https://github.com/Carthage/Carthage/issues/335#issuecomment-271473161), is to add CosmosView.swift to the list of Public Headers.

![screen shot 2018-05-11 at 11 34 23 am](https://user-images.githubusercontent.com/6937424/39943324-538e857e-5517-11e8-85fd-b5938fa35f02.png)

When setting up the Custom Class in your project, note that Cosmos may not show up in the Module dropdown, but you can just manually type it in and it will work.

![screen shot 2018-05-11 at 11 36 18 am](https://user-images.githubusercontent.com/6937424/39943337-5bced996-5517-11e8-8d27-5795085c2f63.png)
