### PR TITLE
Enable APPLICATION_EXTENSION_API_ONLY

### DIFF
--- a/Cosmos.xcodeproj/project.pbxproj
+++ b/Cosmos.xcodeproj/project.pbxproj
@@ -759,6 +759,7 @@
 		2B622EC41B37BAE50090D81B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -779,6 +780,7 @@
 		2B622EC51B37BAE50090D81B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -874,6 +876,7 @@
 		7E646DB31C04438B00048339 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -895,6 +898,7 @@
 		7E646DB41C04438B00048339 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
This PR enables `APPLICATION_EXTENSION_API_ONLY` to fix the `linking against a dylib which is not safe for use in application extensions` when using Carthage to include the framework.