### PR TITLE
add RTL to settings

### DIFF
--- a/Cosmos/CosmosSettings.swift
+++ b/Cosmos/CosmosSettings.swift
@@ -16,7 +16,9 @@ public struct CosmosSettings {
   
   // MARK: - Star settings
   // -----------------------------
-    
+  /// Override RTL logic
+  public var isRTL: Bool?
+
   /// Border color of an empty star.
   public var emptyBorderColor = CosmosDefaultSettings.emptyBorderColor
   

--- a/Cosmos/CosmosView.swift
+++ b/Cosmos/CosmosView.swift
@@ -105,11 +105,11 @@ Shows: ★★★★☆ (123)
     
     // Create star layers
     // ------------
-    
+    var isRightToLeft = settings.isRTL ?? RightToLeft.isRightToLeft(self)
     var layers = CosmosLayers.createStarLayers(
       rating,
       settings: settings,
-      isRightToLeft: RightToLeft.isRightToLeft(self)
+      isRightToLeft: isRightToLeft
     )
     
     // Create text layer


### PR DESCRIPTION
Adding option in CosmosSettings to set RTL this is needed if you are switching languages and you don't need to close the app, so now from my app, I'm using a function isRTL() and set it to settings.isRTL and this fixed the weird behavior when I switch languages  