### PR TITLE
Update Accessibility Localization (KOR)

### DIFF
--- a/Cosmos/CosmosLocalizedRating.swift
+++ b/Cosmos/CosmosLocalizedRating.swift
@@ -26,7 +26,7 @@ struct CosmosLocalizedRating {
     "hu": "Értékelés",
     "id": "Peringkat",
     "it": "Voto",
-    "ko": "등급",
+    "ko": "별점",
     "lt": "Reitingas",
     "lv": "Vērtējums",
     "nl": "Rating",


### PR DESCRIPTION
- Update localized rating (KOR) "등급" -> "별점"
->In Korean, "등급" feels more like grade, and "별점" is a more fitting word.