### PR TITLE
Fix for https://github.com/evgenyneu/Cosmos/issues/204

### DIFF
--- a/Demo/CosmosSettingsObjCBridge.swift
+++ b/Demo/CosmosSettingsObjCBridge.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Cosmos
 
 /**
  
@@ -23,7 +24,7 @@ import UIKit
  [CosmosSettingsObjCBridge setUpdateOnTouch: NO inCosmosView:self.cosmosView];
  
  */
-@objc public class CosmosSettingsObjCBridge: NSObject {
+@objcMembers public class CosmosSettingsObjCBridge: NSObject {
   
   
   /**


### PR DESCRIPTION
1) Resolved "Cannot find type 'XXX' in scope" by adding `import Cosmos` 2) Resolved "No known class method for selector 'YYY'" by replacing `@objc` by `@objcMembers` so all methods within the class will be exposed to Objective-C.